### PR TITLE
Pass `loginProvider` prop to Modal

### DIFF
--- a/packages/react-app/src/components/Modal.jsx
+++ b/packages/react-app/src/components/Modal.jsx
@@ -135,6 +135,7 @@ const Modal = (props) => {
           depositChainProvider={getRpcUrl(chain.depositChainId)}
           withdrawChainProvider={getRpcUrl(chain.withdrawChainId)}
           injectedProvider={web3Provider}
+          loginProvider={window.ethereum}
         />
       ) : (
         <h1>Loading...</h1>


### PR DESCRIPTION
We should hook up the login provider so that users can connect this to their metamask.